### PR TITLE
Make immutable Calculator the default

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -35,7 +35,6 @@ jobs:
           { runs_on: 'ubuntu-latest',  rust: "x86_64-unknown-linux-gnu" },
         ]
         python: [
-            {py: '3.6', interpreter: "python3.6"},
             {py: '3.7', interpreter: "python3.7"},
             {py: '3.8', interpreter: "python3.8"},
             {py: '3.9', interpreter: "python3.9"},
@@ -117,7 +116,6 @@ jobs:
           { runs_on: 'windows-latest', rust: "x86_64-pc-windows-msvc" },
         ]
         python: [
-            {py: '3.6', interpreter: "python3.6"},
             {py: '3.7', interpreter: "python3.7"},
             {py: '3.8', interpreter: "python3.8"},
             {py: '3.9', interpreter: "python3.9"},
@@ -156,7 +154,6 @@ jobs:
           { runs_on: 'macOS-latest', rust: "aarch64-apple-darwin" },
         ]
         python: [
-            {py: '3.6', interpreter: "python3.6"},
             {py: '3.7', interpreter: "python3.7"},
             {py: '3.8', interpreter: "python3.8"},
             {py: '3.9', interpreter: "python3.9"},

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -49,7 +49,6 @@ jobs:
           { runs_on: "windows-latest", rust: "x86_64-pc-windows-msvc" },
         ]
         python: [
-            {py: '3.6', interpreter: "python3.6"},
             {py: '3.7', interpreter: "python3.7"},
             {py: '3.8', interpreter: "python3.8"},
             {py: '3.9', interpreter: "python3.9"},
@@ -81,7 +80,6 @@ jobs:
           { runs_on: "ubuntu-latest",  rust: "x86_64-unknown-linux-gnu" },
         ]
         python: [
-            {py: '3.6', interpreter: "python3.6"},
             {py: '3.7', interpreter: "python3.7"},
             {py: '3.8', interpreter: "python3.8"},
             {py: '3.9', interpreter: "python3.9"},
@@ -114,7 +112,6 @@ jobs:
           { runs_on: 'ubuntu-latest',  rust: "x86_64-unknown-linux-gnu" },
         ]
         python: [
-            {py: '3.6', interpreter: "python3.6"},
             {py: '3.7', interpreter: "python3.7"},
             {py: '3.8', interpreter: "python3.8"},
             {py: '3.9', interpreter: "python3.9"},
@@ -183,7 +180,6 @@ jobs:
           { runs_on: 'windows-latest', rust: "x86_64-pc-windows-msvc" },
         ]
         python: [
-            {py: '3.6', interpreter: "python3.6"},
             {py: '3.7', interpreter: "python3.7"},
             {py: '3.8', interpreter: "python3.8"},
             {py: '3.9', interpreter: "python3.9"},
@@ -216,7 +212,6 @@ jobs:
           { runs_on: 'macOS-latest', rust: "aarch64-apple-darwin" },
         ]
         python: [
-            {py: '3.6', interpreter: "python3.6"},
             {py: '3.7', interpreter: "python3.7"},
             {py: '3.8', interpreter: "python3.8"},
             {py: '3.9', interpreter: "python3.9"},

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -1,0 +1,37 @@
+name: documentation
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+
+  publish_documentation:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        target: x86_64-unknown-linux-gnu
+        default: true
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip maturin
+        pip install ./qoqo_calculator_pyo3/
+        python -m pip install -r qoqo_calculator_pyo3/docs/requirements.txt
+    - name: build
+      run: |
+        cd qoqo_calculator_pyo3/docs
+        python -m sphinx -T -E -b html . _build/html
+        cd ../../
+    - name: publish
+      uses: peaceiris/actions-gh-pages@v3
+      if: ${{ github.ref == 'refs/heads/main' }}
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./qoqo_calculator_pyo3/docs/_build/html/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ coveragehtml/*
 *__pycache__*
 *.pytest_cache*
 *.vscode*
+*/docs/generated*
+*/docs/_build*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This changelog track changes to the qoqo_calculator project starting at version 
 ## Changed
 
 * Default towards immutable Calculator not allowing variable assignments to avoid side effects. The `parse_str` and `parse_get` functions now take immutable Calculator references and return an error when parsing variable assignments. The old behaviour has been moved to the `parse_str_aassign` function of Calculator.
+* Increased minimal Python version to 3.7
+
+## Added
+
+* FromStr implementation for CalculatorFloat that performs a partial sanity check of expressions scanning for unrecognized string sequences and assignments.
+* Default for CalculatorFloat
+* abs() alias for norm() function in CalculatorComplex
 
 ## 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 This changelog track changes to the qoqo_calculator project starting at version 0.6.0
 
-
 ## Not released
+
+## Changed
+
+* Default towards immutable Calculator not allowing variable assignments to avoid side effects. The `parse_str` and `parse_get` functions now take immutable Calculator references and return an error when parsing variable assignments. The old behaviour has been moved to the `parse_str_aassign` function of Calculator.
 
 ## 0.6.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "qoqo_calculator"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "num-complex",
  "schemars",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "qoqo_calculator_pyo3"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "num-complex",
  "pyo3",

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains two components:
 
 ## qoqo_calculator
 
+
 [![Crates.io](https://img.shields.io/crates/v/qoqo_calculator)](https://crates.io/crates/qoqo_calculator)
 [![GitHub Workflow Status](https://github.com/HQSquantumsimulations/qoqo_calculator/workflows/ci_tests/badge.svg)](https://github.com/HQSquantumsimulations/qoqo_calculator/actions)
 [![docs.rs](https://img.shields.io/docsrs/qoqo_calculator)](https://docs.rs/qoqo_calculator/)
@@ -29,6 +30,7 @@ This software is still in the beta stage. Functions and documentation are not ye
 
 [![Crates.io](https://img.shields.io/crates/v/qoqo_calculator_pyo3)](https://crates.io/crates/qoqo_calculator_pyo3)
 [![GitHub Workflow Status](https://github.com/HQSquantumsimulations/qoqo_calculator_pyo3/workflows/ci_tests/badge.svg)](https://github.com/HQSquantumsimulations/qoqo_calculator_pyo3/actions)
+[![Documentation Status](https://img.shields.io/badge/docs-documentation-green)](https://hqsquantumsimulations.github.io/qoqo_calculaotr_pyo3/)
 [![docs.rs](https://img.shields.io/docsrs/qoqo_calculator_pyo3)](https://docs.rs/qoqo_calculator_pyo3/)
 ![Crates.io](https://img.shields.io/crates/l/qoqo_calculator_pyo3)
 [![PyPI](https://img.shields.io/pypi/v/qoqo_calculator_pyo3)](https://pypi.org/project/qoqo_calculator_pyo3/)
@@ -36,7 +38,7 @@ This software is still in the beta stage. Functions and documentation are not ye
 
 Python interface to qoqo calculator, the calculator backend of the qoqo quantum computing toolkit by [HQS Quantum Simulations](https://quantumsimulations.de).
 
-qoqo-calculator-py03 provides
+qoqo-calculator-pyo3 provides
 
 * A calculator python class that evaluates symbolic string expressions to float values
 * A CalculatorFloat python class that can represent a float value or a string based symbolic expression
@@ -54,7 +56,7 @@ pip install qoqo-calculator-pyo3
 
 When building manually we recommend using [maturin](https://github.com/PyO3/maturin) to build the python package.
 
-A source distribution now exists but requires a Rust install with a rust version > 1.47 and a maturin version { >= 0.12, <0.13 } in order to be built.
+A source distribution exists but requires a Rust install with a rust version > 1.47 and a maturin version { >= 0.12, <0.13 } in order to be built.
 
 ## Contributing
 

--- a/qoqo_calculator/Cargo.toml
+++ b/qoqo_calculator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qoqo_calculator"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/qoqo_calculator/Cargo.toml
+++ b/qoqo_calculator/Cargo.toml
@@ -18,7 +18,6 @@ crate-type = ["rlib"]
 num-complex = {version= "0.4", features=['serde']}
 serde = { version = '1.0', features = ["derive"] }
 thiserror = "1.0"
-# schemars = { version = "0.8", optional=true }
 schemars = { version = "0.8", optional=true }
 
 

--- a/qoqo_calculator/src/calculator.rs
+++ b/qoqo_calculator/src/calculator.rs
@@ -200,8 +200,25 @@ impl Calculator {
     ///
     /// * `expression` - Expression that is parsed
     ///
-    pub fn parse_str(&mut self, expression: &str) -> Result<f64, CalculatorError> {
-        let mut parser = Parser::new(expression, self);
+    pub fn parse_str(&self, expression: &str) -> Result<f64, CalculatorError> {
+        let mut parser = ParserEnum::new_immutable(expression, self);
+        let end_value = parser.evaluate_all_tokens()?;
+        match end_value {
+            None => Err(CalculatorError::NoValueReturnedParsing),
+            Some(x) => Ok(x),
+        }
+    }
+
+    ///  Parse a string expression allowing variable assignments.
+    /// 
+    /// 
+    ///
+    /// # Arguments
+    ///
+    /// * `expression` - Expression that is parsed
+    ///
+    pub fn parse_str_assign(&mut self, expression: &str) -> Result<f64, CalculatorError> {
+        let mut parser = ParserEnum::new_mutable(expression, self);
         let end_value = parser.evaluate_all_tokens()?;
         match end_value {
             None => Err(CalculatorError::NoValueReturnedParsing),
@@ -215,7 +232,7 @@ impl Calculator {
     ///
     /// * `parse_variable` - Parsed string CalculatorFloat or returns float value
     ///
-    pub fn parse_get(&mut self, parse_variable: CalculatorFloat) -> Result<f64, CalculatorError> {
+    pub fn parse_get(&self, parse_variable: CalculatorFloat) -> Result<f64, CalculatorError> {
         match parse_variable {
             CalculatorFloat::Float(x) => Ok(x),
             CalculatorFloat::Str(expression) => self.parse_str(&expression),
@@ -224,46 +241,43 @@ impl Calculator {
 }
 
 /// Enum combining different types of Tokens in an Expression.
-///
-/// # Variants
-///
-/// * `Number` - A float or integer
-/// * `VariableOr` - A variable
-/// * `Function` - A  known function
-/// * `Plus` - Plus
-/// * `Minus` - Minus
-/// * `Multiply` - Multiply
-/// * `Divide` - Divide
-/// * `Power` - Power
-/// * `Factorial` - Factorial
-/// * `DoubleFactorial` - DoubleFactorial
-/// * `BracketOpen` - A bracket opening
-/// * `BracketClose` - A bracket closing
-/// * `VariableAssign` - Assignment of a variable
-/// * `Comma` - Comma
-/// * `EndOfExpression` - End of expression
-/// * `EndOfString` - End of parsed string
-/// * `Unrecognized` - No Token has been recognized in string
-///
 #[derive(Debug, Clone, PartialEq)]
 enum Token {
+    /// A float or integer
     Number(f64),
+    /// A variable
     Variable(String),
+    /// A  known function
     Function(String),
+    /// Plus
     Plus,
+    /// Minus
     Minus,
+    /// Multiply
     Multiply,
+    /// Divice
     Divide,
+    /// Poser
     Power,
+    /// Factorial
     Factorial,
+    /// DoubleFactorial
     DoubleFactorial,
+    /// A bracket opening
     BracketOpen,
+    /// A bracket closing
     BracketClose,
+    /// Assign operator
     Assign,
+    /// Assignment of a variable
     VariableAssign(String),
+    /// Comma
     Comma,
+    /// End of Expression
     EndOfExpression,
+    /// End of parsed string
     EndOfString,
+    /// No Token has been recognized in string
     Unrecognized,
 }
 
@@ -299,7 +313,7 @@ struct TokenIterator<'a> {
     // Save current expression as a slice of a string so we do not
     // need to copy but only modify (shorten) the slice.
     //
-    /// * `current_expression` - Current str expression being lexed
+    /// Current str expression being lexed
     current_expression: &'a str,
 }
 
@@ -500,50 +514,154 @@ impl<'a> TokenIterator<'a> {
     }
 }
 
-/// Parse string to float using TokenIterator lexer.
-///
-/// # Fields
-///
-/// * `remaining_expression` - Expression that has not been parsed yet
-/// * `current_token` - Token that is currently parsed
-/// * `calculator` - Calculator that contains set variables
-///
-struct Parser<'a> {
+// /// Parser from &str to f64 using TokenIterator lexer.
+// struct Parser<'a> {
+//     /// Expression that has not been parsed yet
+//     remaining_expression: &'a str,
+//     /// Token that is currently parsed
+//     current_token: Token,
+//     /// Calculator that contains set variables
+//     calculator: &'a mut Calculator,
+// }
+
+/// Parser from &str to f64 using TokenIterator lexer.
+enum ParserEnum<'a> {
+    MutableCalculator{
+        /// Expression that has not been parsed yet
     remaining_expression: &'a str,
+    /// Token that is currently parsed
     current_token: Token,
+    /// Calculator that contains set variables
     calculator: &'a mut Calculator,
+    },
+    ImmutableCalculator{
+        /// Expression that has not been parsed yet
+    remaining_expression: &'a str,
+    /// Token that is currently parsed
+    current_token: Token,
+    /// Calculator that contains set variables
+    calculator: &'a Calculator,
+    },
 }
-impl<'a, 'b> Parser<'a>
-where
-    'b: 'a,
-{
-    /// Initialize a new instance of Parser.
-    fn new(expression: &'a str, calculator: &'b mut Calculator) -> Self {
+
+impl<'a, 'b> ParserEnum<'a> where 'b: 'a {
+
+    /// Get variable for Calculator.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Name of the variable
+    ///
+    /// # Returns
+    ///
+    /// `value` - Result
+    ///
+    #[inline]
+    pub fn get_variable(&self, name: &str) -> Result<f64, CalculatorError> {
+       match &self{
+           &Self::MutableCalculator{calculator, ..} => calculator.get_variable(name),
+           &Self::ImmutableCalculator{calculator, ..} => calculator.get_variable(name)
+       }
+    }
+
+    /// Set variable for Calculator.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Name of the variable
+    /// * `value` - Float value of the variable
+    #[inline]
+    pub fn set_variable(&mut self, name: &str, value: f64) -> Result<(), CalculatorError> {
+        match self{
+            Self::MutableCalculator{calculator, ..} => calculator.set_variable(name,value),
+            Self::ImmutableCalculator{..} => return Err(CalculatorError::ParsingError{msg: "Assign operation not allowed when using"})
+        }
+        Ok(())
+    }
+
+    fn new_mutable(expression: &'a str, calculator: &'b mut Calculator) -> Self {
         let (next_token, next_str) = (TokenIterator {
             current_expression: expression,
         })
         .next_token_and_str();
-        Parser {
+        ParserEnum::MutableCalculator {
             remaining_expression: next_str,
             current_token: next_token.unwrap(),
             calculator,
         }
     }
 
+    fn new_immutable(expression: &'a str, calculator: &'b Calculator) -> Self {
+        let (next_token, next_str) = (TokenIterator {
+            current_expression: expression,
+        })
+        .next_token_and_str();
+        ParserEnum::ImmutableCalculator {
+            remaining_expression: next_str,
+            current_token: next_token.unwrap(),
+            calculator,
+        }
+    }
+
+    fn remaining_expression(&mut self) -> &'a str{
+        match self{
+            ParserEnum::MutableCalculator { remaining_expression, .. } => remaining_expression,
+            ParserEnum::ImmutableCalculator { remaining_expression, .. } => remaining_expression,
+        }
+    }
+
+    fn current_token(&self) -> &Token{
+        match self{
+            ParserEnum::MutableCalculator {  current_token, .. } =>current_token,
+            ParserEnum::ImmutableCalculator {  current_token, .. } => current_token,
+        }
+    }
+
+
+
+// impl<'a, 'b> Parser<'a>
+// where
+//     'b: 'a,
+// {
+
+    /// Get Variable form internal 
+
+    // /// Initialize a new instance of Parser.
+    // fn new(expression: &'a str, calculator: &'b mut Calculator) -> Self {
+    //     let (next_token, next_str) = (TokenIterator {
+    //         current_expression: expression,
+    //     })
+    //     .next_token_and_str();
+    //     Parser {
+    //         remaining_expression: next_str,
+    //         current_token: next_token.unwrap(),
+    //         calculator,
+    //     }
+    // }
+
     /// Get next token via TokenIterator.
     fn next_token(&mut self) {
         let (next_token, next_str) = (TokenIterator {
-            current_expression: self.remaining_expression,
+            current_expression: self.remaining_expression(),
         })
         .next_token_and_str();
         match next_token {
             None => {
-                self.current_token = Token::EndOfString;
-                self.remaining_expression = "";
+                match self{
+                    ParserEnum::MutableCalculator { remaining_expression, current_token, .. } => {*current_token = Token::EndOfString;
+                        *remaining_expression = "";},
+                    ParserEnum::ImmutableCalculator { remaining_expression, current_token, .. } => {*current_token = Token::EndOfString;
+                        *remaining_expression = "";},
+                }
+                
             }
             Some(t) => {
-                self.current_token = t;
-                self.remaining_expression = next_str;
+                match self{
+                    ParserEnum::MutableCalculator { remaining_expression, current_token, .. } => {*current_token = t;
+                        *remaining_expression = next_str;},
+                    ParserEnum::ImmutableCalculator { remaining_expression, current_token, .. } => {*current_token = t;
+                        *remaining_expression = next_str;},
+                }
             }
         }
     }
@@ -552,9 +670,9 @@ where
     /// or return error.
     fn evaluate_all_tokens(&mut self) -> Result<Option<f64>, CalculatorError> {
         let mut current_value: Option<f64> = None;
-        while self.current_token != Token::EndOfString {
+        while self.current_token() != &Token::EndOfString {
             current_value = self.evaluate_init()?;
-            while self.current_token == Token::EndOfExpression {
+            while self.current_token() == &Token::EndOfExpression {
                 self.next_token();
             }
         }
@@ -563,15 +681,15 @@ where
 
     /// Initialize the evaluation of an expression.
     fn evaluate_init(&mut self) -> Result<Option<f64>, CalculatorError> {
-        if self.current_token == Token::EndOfExpression || self.current_token == Token::EndOfString
+        if self.current_token() == &Token::EndOfExpression || self.current_token() == &Token::EndOfString
         {
             Err(CalculatorError::UnexpectedEndOfExpression)
         } else {
-            if let Token::VariableAssign(ref vs) = (*self).current_token {
+            if let Token::VariableAssign(ref vs) = (*self).current_token() {
                 let vsnew = vs.to_owned();
                 self.next_token();
                 let res = self.evaluate_binary_1()?;
-                self.calculator.set_variable(&vsnew, res);
+                self.set_variable(&vsnew, res)?;
                 return Ok(Some(res));
             }
             Ok(Some(self.evaluate_binary_1()?))
@@ -581,8 +699,8 @@ where
     /// Evaluate least preference binary expression (+, -).
     fn evaluate_binary_1(&mut self) -> Result<f64, CalculatorError> {
         let mut res = self.evaluate_binary_2()?;
-        while self.current_token == Token::Plus || self.current_token == Token::Minus {
-            let bsum: bool = self.current_token == Token::Plus;
+        while self.current_token() == &Token::Plus || self.current_token() == &Token::Minus {
+            let bsum: bool = self.current_token() == &Token::Plus;
             self.next_token();
             let val = self.evaluate_binary_2()?;
             if bsum {
@@ -597,8 +715,8 @@ where
     /// Evaluate middle preference binary expression (*, /).
     fn evaluate_binary_2(&mut self) -> Result<f64, CalculatorError> {
         let mut res = self.evaluate_binary_3()?;
-        while self.current_token == Token::Multiply || self.current_token == Token::Divide {
-            let bmul: bool = self.current_token == Token::Multiply;
+        while self.current_token() == &Token::Multiply || self.current_token() == &Token::Divide {
+            let bmul: bool = self.current_token() == &Token::Multiply;
             self.next_token();
             let val = self.evaluate_binary_3()?;
             if bmul {
@@ -616,7 +734,7 @@ where
     /// Evaluate least preference binary expression (^, !).
     fn evaluate_binary_3(&mut self) -> Result<f64, CalculatorError> {
         let mut res = self.evaluate_unary()?;
-        match self.current_token {
+        match self.current_token() {
             Token::DoubleFactorial => {
                 return Err(CalculatorError::NotImplementedError {
                     fct: "DoubleFactorial",
@@ -637,7 +755,7 @@ where
     /// Handle any unary + or - signs.
     fn evaluate_unary(&mut self) -> Result<f64, CalculatorError> {
         let mut prefactor: f64 = 1.0;
-        match self.current_token {
+        match self.current_token() {
             Token::Minus => {
                 self.next_token();
                 prefactor = -1.0;
@@ -652,14 +770,14 @@ where
 
     /// Handle numbers, variables, functions and parentheses.
     fn evaluate(&mut self) -> Result<f64, CalculatorError> {
-        match (*self).current_token {
+        match self.current_token().clone() {
             Token::BracketOpen => {
                 self.next_token();
                 let res_init = self.evaluate_init()?.ok_or(CalculatorError::ParsingError {
                     msg: "Unexpected None return",
                 })?;
                 //self.next_token()?;
-                if self.current_token != Token::BracketClose {
+                if self.current_token() != &Token::BracketClose {
                     Err(CalculatorError::ParsingError {
                         msg: "Expected Braket close",
                     })
@@ -675,7 +793,7 @@ where
             Token::Variable(ref vs) => {
                 let vsnew = vs.to_owned();
                 self.next_token();
-                self.calculator.get_variable(&vsnew)
+                self.get_variable(&vsnew)
             }
             Token::Function(ref vs) => {
                 let vsnew = vs.to_owned();
@@ -689,7 +807,7 @@ where
                     );
                     // Swallow commas in function arguments
                     if argument_number < number_arguments - 1 {
-                        if self.current_token != Token::Comma {
+                        if self.current_token() != &Token::Comma {
                             return Err(CalculatorError::ParsingError {
                                 msg: "expected comma in function arguments",
                             });
@@ -699,7 +817,7 @@ where
                     }
                     //self.next_token()?;
                 }
-                if self.current_token != Token::BracketClose {
+                if self.current_token() != &Token::BracketClose {
                     return Err(CalculatorError::ParsingError {
                         msg: "Expected braket close.",
                     });
@@ -980,8 +1098,20 @@ mod tests {
     // Test parse_string for a variable Token
     #[test]
     fn test_parse_variable() {
-        let mut calculator = Calculator::new();
+        let calculator = Calculator::new();
         let value = calculator.parse_str("a=3; 2*(a+1);");
+        assert!(value.is_err());
+        let value = calculator.parse_str("2*(3+1);");
+        assert!(value.is_err());
+        assert_eq!(value.unwrap(), 8.0);
+    }
+
+    // Test parse_string for a variable Token
+    #[test]
+    fn test_parse_assign_variable() {
+        let mut calculator = Calculator::new();
+        let value = calculator.parse_str_assign("a=3; 2*(a+1);");
+        assert!(value.is_err());
         assert_eq!(value.unwrap(), 8.0);
         assert_eq!(calculator.get_variable("a").unwrap(), 3.0);
     }
@@ -990,21 +1120,21 @@ mod tests {
     #[test]
     fn test_parse_variable_underscore() {
         let mut calculator = Calculator::new();
-        let value = calculator.parse_str("a_1=3; 2*(a_1+1);");
+        let value = calculator.parse_str_assign("a_1=3; 2*(a_1+1);");
         assert_eq!(value.unwrap(), 8.0);
         assert_eq!(calculator.get_variable("a_1").unwrap(), 3.0);
     }
 
     // Test parse_string for a function Token
     #[test]
-    fn test_parse_function() {
+    fn test_parse_assing_function() {
         let f: f64 = 4.0;
         let mut calculator = Calculator::new();
-        let value = calculator.parse_str("a=3; sin(a+1);");
+        let value = calculator.parse_str_assign("a=3; sin(a+1);");
         assert_eq!(value.unwrap(), f.sin());
         assert_eq!(calculator.get_variable("a").unwrap(), 3.0);
 
-        let value = calculator.parse_str("atan2(a+1,2e0);");
+        let value = calculator.parse_str_assign("atan2(a+1,2e0);");
         assert_eq!(value.unwrap(), f.atan2(2e0));
         assert_eq!(calculator.get_variable("a").unwrap(), 3.0);
     }
@@ -1012,7 +1142,7 @@ mod tests {
     // Test parse_get function
     #[test]
     fn test_parse_get() {
-        let mut calculator = Calculator::new();
+        let calculator = Calculator::new();
 
         let cf_float = CalculatorFloat::from(3.0);
         let value_cf_float = calculator.parse_get(cf_float);
@@ -1026,7 +1156,7 @@ mod tests {
     // Test that all evaluate functions match statements return the expected float/error
     #[test]
     fn test_evaluate_functions() {
-        let mut calculator = Calculator::new();
+        let calculator = Calculator::new();
 
         // Evaluate unary function: + and -
         let value = calculator.parse_str("-2");
@@ -1070,7 +1200,7 @@ mod tests {
         let value = calculator.parse_str("3");
         assert_eq!(value.unwrap(), 3.0);
         let value = calculator.parse_str("x=3; x+2");
-        assert_eq!(value.unwrap(), 5.0);
+        assert!(value.is_err());
         let value = calculator.parse_str("max(3, 2)");
         assert_eq!(value.unwrap(), 3.0);
         let value = calculator.parse_str("max(3 2)");

--- a/qoqo_calculator/src/calculator_complex.rs
+++ b/qoqo_calculator/src/calculator_complex.rs
@@ -108,8 +108,8 @@ impl<'de> Deserialize<'de> for CalculatorComplex {
 impl Default for CalculatorComplex {
     fn default() -> Self {
         CalculatorComplex {
-            re: CalculatorFloat::from(0),
-            im: CalculatorFloat::from(0),
+            re:         CalculatorFloat::Float(0.0),
+            im:         CalculatorFloat::Float(0.0),
         }
     }
 }
@@ -123,6 +123,17 @@ impl Default for CalculatorComplex {
 impl<'a> From<&'a CalculatorComplex> for CalculatorComplex {
     fn from(item: &'a CalculatorComplex) -> Self {
         (*item).clone()
+    }
+}
+
+/// I
+impl<T1, T2> From<(T1, T2)> for CalculatorComplex
+where 
+    T1: Into<CalculatorFloat>,
+    T2: Into<CalculatorFloat>
+    {
+        fn from(input: (T1, T2)) -> Self {
+        CalculatorComplex{re: input.0.into(), im: input.1.into()}
     }
 }
 
@@ -256,12 +267,12 @@ impl CalculatorComplex {
     ///
     pub fn new<T1, T2>(re: T1, im: T2) -> Self
     where
-        CalculatorFloat: From<T1>,
-        CalculatorFloat: From<T2>,
+        T1: Into<CalculatorFloat>,
+        T2: Into<CalculatorFloat>,
     {
         Self {
-            re: CalculatorFloat::from(re),
-            im: CalculatorFloat::from(im),
+            re: re.into(),
+            im: im.into(),
         }
     }
 
@@ -277,6 +288,12 @@ impl CalculatorComplex {
     pub fn norm(&self) -> CalculatorFloat {
         ((self.re.clone() * &self.re) + (self.im.clone() * &self.im)).sqrt()
     }
+
+    /// Return absolute value of complex number x: |x|=(x.re^2+x.im^2)^1/2.
+    pub fn abs(&self) -> CalculatorFloat {
+        self.norm()
+    }
+
     /// Return complex conjugate of x: x*=x.re-i*x.im.
     pub fn conj(&self) -> CalculatorComplex {
         Self {
@@ -287,9 +304,9 @@ impl CalculatorComplex {
     /// Return true when x is close to y.
     pub fn isclose<T>(&self, other: T) -> bool
     where
-        CalculatorComplex: From<T>,
+        T: Into<CalculatorComplex>,
     {
-        let other_from = Self::from(other);
+        let other_from: CalculatorComplex = other.into();
         self.re.isclose(other_from.re) && self.im.isclose(other_from.im)
     }
 }
@@ -302,11 +319,11 @@ impl CalculatorComplex {
 ///
 impl<T> ops::Add<T> for CalculatorComplex
 where
-    CalculatorComplex: From<T>,
+    T: Into<CalculatorComplex>,
 {
     type Output = Self;
     fn add(self, other: T) -> Self {
-        let other_from = Self::from(other);
+        let other_from = other.into();
         CalculatorComplex {
             re: self.re + other_from.re,
             im: self.im + other_from.im,
@@ -338,10 +355,10 @@ impl std::iter::Sum for CalculatorComplex {
 ///
 impl<T> ops::AddAssign<T> for CalculatorComplex
 where
-    CalculatorComplex: From<T>,
+    T: Into<CalculatorComplex>,
 {
     fn add_assign(&mut self, other: T) {
-        let other_from = Self::from(other);
+        let other_from: CalculatorComplex = other.into();
         *self = CalculatorComplex {
             re: &self.re + other_from.re,
             im: &self.im + other_from.im,
@@ -357,11 +374,11 @@ where
 ///
 impl<T> ops::Sub<T> for CalculatorComplex
 where
-    CalculatorComplex: From<T>,
+    T: Into<CalculatorComplex>,
 {
     type Output = Self;
     fn sub(self, other: T) -> Self {
-        let other_from = Self::from(other);
+        let other_from: CalculatorComplex = other.into();
         CalculatorComplex {
             re: self.re - other_from.re,
             im: self.im - other_from.im,
@@ -376,10 +393,10 @@ where
 ///
 impl<T> ops::SubAssign<T> for CalculatorComplex
 where
-    CalculatorComplex: From<T>,
+    T: Into<CalculatorComplex>,
 {
     fn sub_assign(&mut self, other: T) {
-        let other_from = Self::from(other);
+        let other_from: CalculatorComplex = other.into();
         *self = CalculatorComplex {
             re: self.re.clone() - other_from.re,
             im: self.im.clone() - other_from.im,
@@ -407,11 +424,11 @@ impl ops::Neg for CalculatorComplex {
 ///
 impl<T> ops::Mul<T> for CalculatorComplex
 where
-    CalculatorComplex: From<T>,
+    T: Into<CalculatorComplex>,
 {
     type Output = Self;
     fn mul(self, other: T) -> Self {
-        let other_from = Self::from(other);
+        let other_from: CalculatorComplex = other.into();
         CalculatorComplex {
             re: self.re.clone() * &other_from.re - (self.im.clone() * &other_from.im),
             im: self.re * &other_from.im + (self.im * &other_from.re),
@@ -426,10 +443,10 @@ where
 ///
 impl<T> ops::MulAssign<T> for CalculatorComplex
 where
-    CalculatorComplex: From<T>,
+    T: Into<CalculatorComplex>,
 {
     fn mul_assign(&mut self, other: T) {
-        let other_from = Self::from(other);
+        let other_from: CalculatorComplex = other.into();
         *self = CalculatorComplex {
             re: self.re.clone() * &other_from.re - (self.im.clone() * &other_from.im),
             im: self.re.clone() * &other_from.im + (self.im.clone() * &other_from.re),
@@ -445,11 +462,11 @@ where
 ///
 impl<T> ops::Div<T> for CalculatorComplex
 where
-    CalculatorComplex: From<T>,
+    T: Into<CalculatorComplex>,
 {
     type Output = Self;
     fn div(self, other: T) -> Self {
-        let other_from = Self::from(other);
+        let other_from: CalculatorComplex = other.into();
         let norm = other_from.norm_sqr();
         CalculatorComplex {
             re: (self.re.clone() * &other_from.re + (self.im.clone() * &other_from.im)) / &norm,
@@ -465,10 +482,10 @@ where
 ///
 impl<T> ops::DivAssign<T> for CalculatorComplex
 where
-    CalculatorComplex: From<T>,
+    T: Into<CalculatorComplex>,
 {
     fn div_assign(&mut self, other: T) {
-        let other_from = Self::from(other);
+        let other_from: CalculatorComplex = other.into();
         let norm = other_from.norm_sqr();
         *self = CalculatorComplex {
             re: (self.re.clone() * &other_from.re + (self.im.clone() * &other_from.im)) / &norm,
@@ -773,6 +790,13 @@ mod tests {
         let x = CalculatorComplex::new(1, 2);
         let y = Complex::new(1.0, 2.0);
         assert_eq!(x.norm(), CalculatorFloat::from(y.norm()));
+    }
+
+    #[test]
+    fn abs() {
+        let x = CalculatorComplex::new(1, 2);
+        let y = Complex::new(1.0, 2.0);
+        assert_eq!(x.abs(), CalculatorFloat::from(y.norm()));
     }
 
     // Test the conjugate functionality of CalculatorComplex

--- a/qoqo_calculator/src/calculator_complex.rs
+++ b/qoqo_calculator/src/calculator_complex.rs
@@ -108,8 +108,8 @@ impl<'de> Deserialize<'de> for CalculatorComplex {
 impl Default for CalculatorComplex {
     fn default() -> Self {
         CalculatorComplex {
-            re:         CalculatorFloat::Float(0.0),
-            im:         CalculatorFloat::Float(0.0),
+            re: CalculatorFloat::Float(0.0),
+            im: CalculatorFloat::Float(0.0),
         }
     }
 }
@@ -128,12 +128,15 @@ impl<'a> From<&'a CalculatorComplex> for CalculatorComplex {
 
 /// I
 impl<T1, T2> From<(T1, T2)> for CalculatorComplex
-where 
+where
     T1: Into<CalculatorFloat>,
-    T2: Into<CalculatorFloat>
-    {
-        fn from(input: (T1, T2)) -> Self {
-        CalculatorComplex{re: input.0.into(), im: input.1.into()}
+    T2: Into<CalculatorFloat>,
+{
+    fn from(input: (T1, T2)) -> Self {
+        CalculatorComplex{
+            re: input.0.into(),
+            im: input.1.into(),
+        }
     }
 }
 

--- a/qoqo_calculator/src/calculator_complex.rs
+++ b/qoqo_calculator/src/calculator_complex.rs
@@ -133,7 +133,7 @@ where
     T2: Into<CalculatorFloat>,
 {
     fn from(input: (T1, T2)) -> Self {
-        CalculatorComplex{
+        CalculatorComplex {
             re: input.0.into(),
             im: input.1.into(),
         }

--- a/qoqo_calculator/src/calculator_float.rs
+++ b/qoqo_calculator/src/calculator_float.rs
@@ -16,7 +16,7 @@
 //! mathematical expressions in string form to float.
 
 use crate::calculator::{Token, TokenIterator};
-use crate::{CalculatorError};
+use crate::CalculatorError;
 #[cfg(feature = "json_schema")]
 use schemars::schema::*;
 use serde::de::{Deserializer, Error, Visitor};
@@ -703,7 +703,7 @@ where
 {
     type Output = Self;
     fn add(self, other: T) -> Self {
-        let other_from:CalculatorFloat = other.into();
+        let other_from: CalculatorFloat = other.into();
         match self {
             Self::Float(x) => match other_from {
                 Self::Float(y) => CalculatorFloat::Float(x + y),
@@ -844,7 +844,7 @@ where
 {
     type Output = Self;
     fn div(self, other: T) -> Self {
-        let other_from:CalculatorFloat = other.into();
+        let other_from: CalculatorFloat = other.into();
         match self {
             Self::Float(x) => match other_from {
                 Self::Float(y) => {
@@ -1603,7 +1603,7 @@ mod tests {
     }
 
     #[test]
-    fn default(){
+    fn default() {
         let a = CalculatorFloat::default();
         assert_eq!(a, CalculatorFloat::Float(0.0));
     }

--- a/qoqo_calculator/src/calculator_float.rs
+++ b/qoqo_calculator/src/calculator_float.rs
@@ -15,7 +15,8 @@
 //! Provides CalculatorFloat enum and methods for parsing and evaluating
 //! mathematical expressions in string form to float.
 
-use crate::CalculatorError;
+use crate::calculator::{Token, TokenIterator};
+use crate::{CalculatorError};
 #[cfg(feature = "json_schema")]
 use schemars::schema::*;
 use serde::de::{Deserializer, Error, Visitor};
@@ -56,6 +57,13 @@ impl schemars::JsonSchema for CalculatorFloat {
         return_schema.subschemas().one_of =
             Some(vec![<f64>::json_schema(gen), <String>::json_schema(gen)]);
         return_schema.into()
+    }
+}
+
+/// Implement Default value 0 for CalculatorFloat.
+impl Default for CalculatorFloat {
+    fn default() -> Self {
+        CalculatorFloat::Float(0.0)
     }
 }
 
@@ -431,6 +439,38 @@ impl From<&str> for CalculatorFloat {
     }
 }
 
+impl FromStr for CalculatorFloat {
+    type Err = CalculatorError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let f = f64::from_str(s);
+        match f {
+            Err(_) => {
+                let mut tokeniter = TokenIterator {
+                    current_expression: s,
+                };
+                match tokeniter.find(|t| {
+                    matches!(
+                        t,
+                        Token::VariableAssign(_) | Token::Assign | Token::Unrecognized
+                    )
+                }) {
+                    None => Ok(CalculatorFloat::Str(s.to_string())),
+                    Some(t) => match t {
+                        Token::VariableAssign(vs) => {
+                            Err(CalculatorError::NotParsableAssign { variable_name: vs })
+                        }
+                        Token::Assign => Err(CalculatorError::NotParsableSingleAssign),
+                        Token::Unrecognized => Err(CalculatorError::NotParsableUnrecognized),
+                        _ => panic!(""),
+                    },
+                }
+            }
+            Ok(x) => Ok(CalculatorFloat::Float(x)),
+        }
+    }
+}
+
 /// Try turning CalculatorFloat into f64 float.
 ///
 /// # Returns
@@ -537,9 +577,9 @@ impl CalculatorFloat {
     ///
     pub fn atan2<T>(&self, other: T) -> CalculatorFloat
     where
-        CalculatorFloat: From<T>,
+        T: Into<CalculatorFloat>,
     {
-        let other_from = Self::from(other);
+        let other_from: CalculatorFloat = other.into();
         match self {
             Self::Float(x) => match other_from {
                 Self::Float(y) => CalculatorFloat::Float(x.atan2(y)),
@@ -560,9 +600,9 @@ impl CalculatorFloat {
     ///
     pub fn powf<T>(&self, other: T) -> CalculatorFloat
     where
-        CalculatorFloat: From<T>,
+        T: Into<CalculatorFloat>,
     {
-        let other_from = Self::from(other);
+        let other_from: CalculatorFloat = other.into();
         match self {
             Self::Float(x) => match other_from {
                 Self::Float(y) => CalculatorFloat::Float(x.powf(y)),
@@ -620,9 +660,9 @@ impl CalculatorFloat {
     /// Return True if self value is close to other value.
     pub fn isclose<T>(&self, other: T) -> bool
     where
-        CalculatorFloat: From<T>,
+        T: Into<CalculatorFloat>,
     {
-        let other_from = Self::from(other);
+        let other_from: CalculatorFloat = other.into();
         match self {
             Self::Float(x) => match other_from {
                 Self::Float(y) => (x - y).abs() <= (ATOL + RTOL * y.abs()),
@@ -659,11 +699,11 @@ impl CalculatorFloat {
 ///
 impl<T> ops::Add<T> for CalculatorFloat
 where
-    CalculatorFloat: From<T>,
+    T: Into<CalculatorFloat>,
 {
     type Output = Self;
     fn add(self, other: T) -> Self {
-        let other_from = Self::from(other);
+        let other_from:CalculatorFloat = other.into();
         match self {
             Self::Float(x) => match other_from {
                 Self::Float(y) => CalculatorFloat::Float(x + y),
@@ -713,10 +753,10 @@ impl std::iter::Sum for CalculatorFloat {
 ///
 impl<T> ops::AddAssign<T> for CalculatorFloat
 where
-    CalculatorFloat: From<T>,
+    T: Into<CalculatorFloat>,
 {
     fn add_assign(&mut self, other: T) {
-        let other_from = CalculatorFloat::from(other);
+        let other_from: CalculatorFloat = other.into();
 
         match self {
             Self::Float(x) => match other_from {
@@ -800,11 +840,11 @@ where
 ///
 impl<T> ops::Div<T> for CalculatorFloat
 where
-    CalculatorFloat: From<T>,
+    T: Into<CalculatorFloat>,
 {
     type Output = Self;
     fn div(self, other: T) -> Self {
-        let other_from = Self::from(other);
+        let other_from:CalculatorFloat = other.into();
         match self {
             Self::Float(x) => match other_from {
                 Self::Float(y) => {
@@ -851,10 +891,10 @@ where
 ///
 impl<T> ops::DivAssign<T> for CalculatorFloat
 where
-    CalculatorFloat: From<T>,
+    T: Into<CalculatorFloat>,
 {
     fn div_assign(&mut self, other: T) {
-        let other_from = Self::from(other);
+        let other_from: CalculatorFloat = other.into();
         match self {
             Self::Float(x) => match other_from {
                 Self::Float(y) => {
@@ -902,11 +942,11 @@ where
 ///
 impl<T> ops::Mul<T> for CalculatorFloat
 where
-    CalculatorFloat: From<T>,
+    T: Into<CalculatorFloat>,
 {
     type Output = Self;
     fn mul(self, other: T) -> Self {
-        let other_from = Self::from(other);
+        let other_from: CalculatorFloat = other.into();
         match self {
             Self::Float(x) => match other_from {
                 Self::Float(y) => Self::Float(x * y),
@@ -936,6 +976,48 @@ where
     }
 }
 
+/// Implement `*` (multiply) for CalculatorFloat and generic type `T`.
+///
+/// # Arguments
+///
+/// * `other` - Any type T for which CalculatorFloat::From<T> trait is implemented
+///
+impl<T> ops::Mul<T> for &CalculatorFloat
+where
+    T: Into<CalculatorFloat>,
+{
+    type Output = CalculatorFloat;
+    fn mul(self, other: T) -> CalculatorFloat {
+        let other_from: CalculatorFloat = other.into();
+        match self {
+            CalculatorFloat::Float(x) => match other_from {
+                CalculatorFloat::Float(y) => CalculatorFloat::Float(x * y),
+                CalculatorFloat::Str(y) => {
+                    if *x == 0.0 {
+                        CalculatorFloat::Float(0.0)
+                    } else if (x - 1.0).abs() < ATOL {
+                        CalculatorFloat::Str(y)
+                    } else {
+                        CalculatorFloat::Str(format!("({:e} * {})", x, &y))
+                    }
+                }
+            },
+            CalculatorFloat::Str(x) => match other_from {
+                CalculatorFloat::Float(y) => {
+                    if y == 0.0 {
+                        CalculatorFloat::Float(0.0)
+                    } else if (y - 1.0).abs() < ATOL {
+                        CalculatorFloat::Str(x.to_string())
+                    } else {
+                        CalculatorFloat::Str(format!("({} * {:e})", &x, y))
+                    }
+                }
+                CalculatorFloat::Str(y) => CalculatorFloat::Str(format!("({} * {})", x, y)),
+            },
+        }
+    }
+}
+
 /// Implement `*=` (multiply) for CalculatorFloat and generic type `T`.
 ///
 /// # Arguments
@@ -944,10 +1026,10 @@ where
 ///
 impl<T> ops::MulAssign<T> for CalculatorFloat
 where
-    CalculatorFloat: From<T>,
+    T: Into<CalculatorFloat>,
 {
     fn mul_assign(&mut self, other: T) {
-        let other_from = Self::from(other);
+        let other_from: CalculatorFloat = other.into();
         match self {
             Self::Float(x) => match other_from {
                 Self::Float(y) => {
@@ -991,11 +1073,11 @@ where
 ///
 impl<T> ops::Sub<T> for CalculatorFloat
 where
-    CalculatorFloat: From<T>,
+    T: Into<CalculatorFloat>,
 {
     type Output = Self;
     fn sub(self, other: T) -> Self {
-        let other_from = Self::from(other);
+        let other_from: CalculatorFloat = other.into();
         match self {
             CalculatorFloat::Float(x) => match other_from {
                 CalculatorFloat::Float(y) => CalculatorFloat::Float(x - y),
@@ -1029,10 +1111,10 @@ where
 ///
 impl<T> ops::SubAssign<T> for CalculatorFloat
 where
-    CalculatorFloat: From<T>,
+    T: Into<CalculatorFloat>,
 {
     fn sub_assign(&mut self, other: T) {
-        let other_from = Self::from(other);
+        let other_from: CalculatorFloat = other.into();
         match self {
             Self::Float(x) => match other_from {
                 Self::Float(y) => {
@@ -1082,7 +1164,7 @@ mod tests {
     #[cfg(feature = "json_schema")]
     use schemars::schema_for;
     use serde_test::{assert_tokens, Configure, Token};
-    use std::convert::TryFrom;
+    use std::{convert::TryFrom, str::FromStr};
 
     // Test the serialization/deserialization of CalculatorFloat from string
     #[test]
@@ -1513,6 +1595,34 @@ mod tests {
 
         x3s *= 0.0;
         assert_eq!(x3s, CalculatorFloat::Float(0.0));
+
+        let x4 = &CalculatorFloat::from(4.0);
+        let x5 = &CalculatorFloat::from(5.0);
+
+        assert_eq!(x4 * x5, CalculatorFloat::Float(20.0));
+    }
+
+    #[test]
+    fn default(){
+        let a = CalculatorFloat::default();
+        assert_eq!(a, CalculatorFloat::Float(0.0));
+    }
+
+    #[test]
+    fn from_str() {
+        let expression = "=";
+        let result = CalculatorFloat::from_str(expression);
+        assert!(result.is_err());
+        let expression = "a=3";
+        let result = CalculatorFloat::from_str(expression);
+        assert!(result.is_err());
+        let expression = "?";
+        let result = CalculatorFloat::from_str(expression);
+        assert!(result.is_err());
+        let expression = "a+2";
+        let result = CalculatorFloat::from_str(expression);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), CalculatorFloat::Str("a+2".to_string()))
     }
 
     // Test the subtract functionality of CalculatorFloat with all possible input types

--- a/qoqo_calculator/src/lib.rs
+++ b/qoqo_calculator/src/lib.rs
@@ -90,6 +90,24 @@ pub enum CalculatorError {
     /// Not enough function arguments provided in parsed expression.
     #[error("Not enough function arguments.")]
     NotEnoughFunctionArguments,
+    /// Trying to assign variable in side-effect free parsing.
+    #[error("Trying to assign variable {variable_name} in side-effect free parsing. Set variable in Calculator with .set_variable, replace with number in str or use parse_str_assign to resolve error.")]
+    ForbiddenAssign {
+        /// Name of the variable that is being assigned
+        variable_name: String,
+    },
+    /// Error raised when checking if a String-CalculatorFloat is valid and can be parsed
+    #[error("CalculatorFloat::Str is not a valid expression that can be parsed: Variable assignment to {variable_name}")]
+    NotParsableAssign {
+        /// Name of the variable that is being assigned
+        variable_name: String,
+    },
+    /// Error raised when checking if a String-CalculatorFloat is valid and can be parsed
+    #[error("CalculatorFloat::Str is not a valid expression that can be parsed: Urecognized elements in expression")]
+    NotParsableUnrecognized,
+    /// Error raised when checking if a String-CalculatorFloat is valid and can be parsed
+    #[error("CalculatorFloat::Str is not a valid expression that can be parsed: Assign operator `=` found in expression")]
+    NotParsableSingleAssign,
 }
 
 #[cfg(test)]

--- a/qoqo_calculator_pyo3/Cargo.toml
+++ b/qoqo_calculator_pyo3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qoqo_calculator_pyo3"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["HQS Quantum Simulations <info@quantumsimulations.de>"]
 license = "Apache-2.0"
 edition = "2018"
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 num-complex = "0.4"
-qoqo_calculator = {version="0.6", path="../qoqo_calculator"}
+qoqo_calculator = {version="0.7", path="../qoqo_calculator"}
 serde =  "1.0"
 thiserror = "1.0"
 
@@ -31,4 +31,4 @@ default = ["extension-module"]
 [package.metadata.maturin]
 maintainer = "HQS Quantum Simulations GmbH"
 maintainer-email = "info@quantumsimulations.de"
-requires-python = ">=3.6"
+requires-python = ">=3.7"

--- a/qoqo_calculator_pyo3/docs/Makefile
+++ b/qoqo_calculator_pyo3/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line.
+SPHINXOPTS    =
+SPHINXBUILD   = python -msphinx
+SPHINXPROJ    = qoqo_calculator_pyo3
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/qoqo_calculator_pyo3/docs/conf.py
+++ b/qoqo_calculator_pyo3/docs/conf.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+"""Configuration of sphinx documentation module"""
+import toml
+
+with open('../Cargo.toml') as f:
+    toml_data = toml.load(f)
+version = toml_data["package"]["version"]
+
+versions = version.split(".")
+main_version = "{}.{}".format(versions[0], versions[1])
+
+
+# -- General configuration ------------------------------------------------
+
+# If your documentation needs a minimal Sphinx version, state it here.
+#
+# needs_sphinx = '1.0'
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = ['sphinx.ext.autodoc',
+              'sphinx.ext.doctest',
+              'sphinx.ext.todo',
+              'sphinx.ext.coverage',
+              'sphinx.ext.mathjax',
+              'sphinx.ext.viewcode',
+              'sphinx.ext.napoleon',
+              'sphinx.ext.autosummary',
+              'nbsphinx',
+              'myst_parser']
+# automatically use sphinx-autogen
+autosummary_generate = True
+autosummary_imported_members = True
+# define mock imports for packages that are difficult to handle / install
+alist = []
+autodoc_mock_imports = alist
+
+# 'both': class and __init__ docstring are concatenated and inserted
+# 'class': only class docstring inserted
+# 'init': only init docstring inserted
+autoclass_content = 'class'
+# This value is a list of autodoc directive flags that should be automatically applied to
+# all autodoc directives. The supported flags are 'members', 'undoc-members',
+# 'private-members', 'special-members', 'inherited-members', 'show-inheritance',
+# 'ignore-module-all' and 'exclude-members'.
+#autodoc_default_flags = ['members', 'exclude-members']
+# The default options for autodoc directives. They are applied to all autodoc directives
+# automatically. It must be a dictionary which maps option names to the values.
+autodoc_default_options = {
+    'members': True,
+    'special-members': False,
+    'imported-members': False,
+    'private-members': False,
+    'inherited-members': False,
+    #    'member-order': 'bysource',
+    'special-members': False,
+    'undoc-members': False,
+    'exclude-members': '__init__'}
+# This value controls the docstrings inheritance. If set to True the docstring for classes
+# or methods, if not explicitly set, is inherited form parents.
+autodoc_inherit_docstrings = False
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.txt': 'markdown',
+    '.md': 'markdown',
+}
+
+# The master toctree document.
+master_doc = 'index'
+
+# General information about the project.
+project = 'qoqo_calculator_pyo3'
+copyright = '2021, HQS Quantum Simulations GmbH'
+author = 'The qoqo developers'
+
+# The version info for the project you're documenting, acts as replacement for
+# |version| and |release|, also used in various other places throughout the
+# built documents.
+#
+# The short X.Y version.
+version = main_version
+# The full version, including alpha/beta/rc tags.
+release = version
+
+
+language = 'English'
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This patterns also effect to html_static_path and html_extra_path
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+# The name of the Pygments (syntax highlighting) style to use.
+pygments_style = 'default'
+
+# If true, `todo` and `todoList` produce output, else they produce nothing.
+todo_include_todos = True
+
+
+# -- Options for HTML output ----------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+
+html_theme = "sphinx_rtd_theme"
+# Theme options are theme-specific and customize the look and feel of a theme
+# further.  For a list of options available for each theme, see the
+# documentation.
+#
+# html_theme_options = {}
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+# html_static_path = ['_static']
+html_static_path = []
+
+
+# -- Options for HTMLHelp output ------------------------------------------
+
+# Output file base name for HTML help builder.
+htmlhelp_basename = 'qoqocalculatorpyo3doc'
+
+
+# -- Options for LaTeX output ---------------------------------------------
+
+latex_elements = {
+    # The paper size ('letterpaper' or 'a4paper').
+    #
+    # 'papersize': 'letterpaper',
+
+    # The font size ('10pt', '11pt' or '12pt').
+    #
+    # 'pointsize': '10pt',
+
+    # Additional stuff for the LaTeX preamble.
+    #
+    # 'preamble': '',
+
+    # Latex figure (float) alignment
+    #
+    # 'figure_align': 'htbp',
+}
+
+# Grouping the document tree into LaTeX files. List of tuples
+# (source start file, target name, title,
+#  author, documentclass [howto, manual, or own class]).
+latex_documents = [
+    (master_doc, 'qoqo_calculator_pyo3.tex', 'qoqo_calculator_pyo3 Documentation',
+     'HQS Quantum Simulations GmbH', 'manual'),
+]
+
+
+# -- Options for manual page output ---------------------------------------
+
+# One entry per manual page. List of tuples
+# (source start file, name, description, authors, manual section).
+man_pages = [
+    (master_doc, 'qoqo_calculator_pyo3', 'qoqo_calculator_pyo3 Documentation',
+     [author], 1)
+]
+
+
+# -- Options for Texinfo output -------------------------------------------
+
+# Grouping the document tree into Texinfo files. List of tuples
+# (source start file, target name, title, author,
+#  dir menu entry, description, category)
+texinfo_documents = [
+    (master_doc, 'qoqo_calculator_pyo3', 'qoqo_calculator_pyo3 Documentation',
+     author, 'qoqo_calculator_pyo3', 'Fast symbolic expressions for the qoqo quantum computing toolkit',
+     'Miscellaneous'),
+]
+
+# Turning off executing notebooks when adding them to Documentation
+nbsphinx_execute = 'never'

--- a/qoqo_calculator_pyo3/docs/index.rst
+++ b/qoqo_calculator_pyo3/docs/index.rst
@@ -1,0 +1,18 @@
+Welcome to qoqo_calculator_pyo3's documentation!
+================================================
+
+
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules
+
+
+
+Documentation Index
+==================
+
+* :ref:`genindex`

--- a/qoqo_calculator_pyo3/docs/modules.rst
+++ b/qoqo_calculator_pyo3/docs/modules.rst
@@ -1,0 +1,9 @@
+qoqo_aqt documentation
+========================
+
+.. autosummary::
+    :toctree: generated/
+
+    qoqo_calculator_pyo3
+
+

--- a/qoqo_calculator_pyo3/docs/requirements.txt
+++ b/qoqo_calculator_pyo3/docs/requirements.txt
@@ -1,0 +1,9 @@
+qoqo_calculator_pyo3>=0.7.0
+numpy
+sphinx >= 2.1
+nbsphinx
+pygments
+recommonmark
+myst_parser
+sphinx_rtd_theme
+toml

--- a/qoqo_calculator_pyo3/src/calculator.rs
+++ b/qoqo_calculator_pyo3/src/calculator.rs
@@ -55,7 +55,23 @@ impl CalculatorWrapper {
     ///
     /// * `input` - Expression that is parsed
     ///
-    pub fn parse_str(&mut self, input: &str) -> PyResult<f64> {
+    pub fn parse_str_assign(&mut self, input: &str) -> PyResult<f64> {
+        match self.r_calculator.parse_str_assign(input) {
+            Ok(x) => Ok(x),
+            Err(x) => Err(PyValueError::new_err(format!(
+                "{:?}; expression: {}",
+                x, input
+            ))),
+        }
+    }
+
+    ///  Parse a string expression.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - Expression that is parsed
+    ///
+    pub fn parse_str(&self, input: &str) -> PyResult<f64> {
         match self.r_calculator.parse_str(input) {
             Ok(x) => Ok(x),
             Err(x) => Err(PyValueError::new_err(format!(
@@ -71,7 +87,7 @@ impl CalculatorWrapper {
     ///
     /// * `input` - Parsed string CalculatorFloat or returns float value
     ///
-    pub fn parse_get(&mut self, input: &PyAny) -> PyResult<f64> {
+    pub fn parse_get(&self, input: &PyAny) -> PyResult<f64> {
         let converted = convert_into_calculator_float(input)
             .map_err(|_| PyTypeError::new_err("Input can not be converted to Calculator Float"))?;
         let out = self.r_calculator.parse_get(converted);
@@ -88,9 +104,9 @@ impl CalculatorWrapper {
 ///
 /// * `expression` - Expression that is parsed
 ///
-pub fn parse_str(expression: &str) -> PyResult<f64> {
+pub fn parse_str_assign(expression: &str) -> PyResult<f64> {
     let mut calculator = Calculator::new();
-    match calculator.parse_str(expression) {
+    match calculator.parse_str_assign(expression) {
         Ok(x) => Ok(x),
         Err(x) => Err(PyValueError::new_err(format!(
             "{:?}; expression {}",

--- a/qoqo_calculator_pyo3/src/lib.rs
+++ b/qoqo_calculator_pyo3/src/lib.rs
@@ -47,6 +47,7 @@ fn qoqo_calculator_pyo3(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<CalculatorWrapper>()?;
     m.add_class::<CalculatorFloatWrapper>()?;
     m.add_class::<CalculatorComplexWrapper>()?;
-    m.add_function(wrap_pyfunction!(parse_string_assign, m)?).unwrap();
+    m.add_function(wrap_pyfunction!(parse_string_assign, m)?).
+        unwrap();
     Ok(())
 }

--- a/qoqo_calculator_pyo3/src/lib.rs
+++ b/qoqo_calculator_pyo3/src/lib.rs
@@ -23,12 +23,12 @@ mod calculator_complex;
 pub use calculator_complex::convert_into_calculator_complex;
 pub use calculator_complex::CalculatorComplexWrapper;
 mod calculator;
-pub use calculator::parse_str;
+pub use calculator::parse_str_assign;
 pub use calculator::CalculatorWrapper;
 
 #[pyfunction]
-fn parse_string(expression: &str) -> PyResult<f64> {
-    parse_str(expression)
+fn parse_string_assign(expression: &str) -> PyResult<f64> {
+    parse_str_assign(expression)
 }
 
 /// qoqo_calculator_pyo3 module bringing the qoqo_calculator rust library to Python.

--- a/qoqo_calculator_pyo3/src/lib.rs
+++ b/qoqo_calculator_pyo3/src/lib.rs
@@ -47,6 +47,6 @@ fn qoqo_calculator_pyo3(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<CalculatorWrapper>()?;
     m.add_class::<CalculatorFloatWrapper>()?;
     m.add_class::<CalculatorComplexWrapper>()?;
-    m.add_function(wrap_pyfunction!(parse_string, m)?).unwrap();
+    m.add_function(wrap_pyfunction!(parse_string_assign, m)?).unwrap();
     Ok(())
 }

--- a/qoqo_calculator_pyo3/src/lib.rs
+++ b/qoqo_calculator_pyo3/src/lib.rs
@@ -47,7 +47,7 @@ fn qoqo_calculator_pyo3(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<CalculatorWrapper>()?;
     m.add_class::<CalculatorFloatWrapper>()?;
     m.add_class::<CalculatorComplexWrapper>()?;
-    m.add_function(wrap_pyfunction!(parse_string_assign, m)?).
-        unwrap();
+    m.add_function(wrap_pyfunction!(parse_string_assign, m)?)
+        .unwrap();
     Ok(())
 }


### PR DESCRIPTION
At the moment the functions that use the `Calculator` to parse string expressions into float values take mutable references to `Calculator` and allow setting of variables from the parsed expression. This pull request changes the default to use immutable references and disallow setting of variables form the parsed expression.

The behaviour of the `parse_get` and `parse_str` functions changes. The old functionality has been moved to the `parse_str_assign` function.